### PR TITLE
chore: replace ci_post_clone.sh with iOS-specific version

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,6 +1,0 @@
-    #!/bin/sh
-    echo "--- ci_post_clone.sh Test Script IS RUNNING ---"
-    echo "Listing workspace root:"
-    ls -la /Volumes/workspace/repository
-    echo "--- Test script finished ---"
-    exit 0

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,32 @@
+    #!/bin/sh
+
+    # Exit immediately if a command exits with a non-zero status.
+    set -e
+
+    # --- Flutter Environment Setup ---
+    # This assumes Flutter is available in the Xcode Cloud environment.
+    # Adjust path if necessary, though default environments usually have it.
+    echo "Setting up Flutter..."
+    # Install Flutter dependencies
+    flutter pub get
+
+    # --- Generate Xcode Config Files ---
+    echo "Generating Xcode config files..."
+    # Run flutter build ios to generate Generated.xcconfig and other necessary files
+    # Using --no-codesign as Xcode Cloud will handle signing later
+    flutter build ios --release --no-codesign
+
+    # --- CocoaPods Setup ---
+    echo "Setting up CocoaPods..."
+    # Navigate to the ios directory
+    cd ios
+
+    # Install CocoaPods dependencies
+    # Using repo-update might be needed if Pods are outdated, but can be slower.
+    # Try without it first.
+    # pod install --repo-update
+    pod install
+
+    echo "Post-clone script finished successfully."
+
+    exit 0


### PR DESCRIPTION
Remove the old ci_post_clone.sh script and add a new iOS-specific script that sets up the Flutter environment, generates Xcode config files, and installs CocoaPods dependencies. This update ensures compatibility with the iOS build process in the Xcode Cloud environment.