### PR TITLE
style(agenda_tile): adjust alignment for better spacing

### DIFF
--- a/lib/widgets/agenda_tile.dart
+++ b/lib/widgets/agenda_tile.dart
@@ -161,6 +161,7 @@ class AgendaTile extends StatelessWidget {
             child: Padding(
               padding: EdgeInsets.all(16),
               child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   if (showCheckbox)
                     Padding(
@@ -177,6 +178,7 @@ class AgendaTile extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
                             Flexible(
                               child: Container(
@@ -207,7 +209,6 @@ class AgendaTile extends StatelessWidget {
                                 ),
                               ),
                             ),
-                            SizedBox(width: 8),
                             CustomText2(
                               _getTimeLeft(),
                               fontSize: 12,


### PR DESCRIPTION
This commit adds `MainAxisAlignment.spaceBetween` to two `Row` widgets to improve the spacing and alignment of elements within the `AgendaTile`. It also removes an unnecessary `SizedBox` to streamline the layout.