### PR TITLE
feat(widgets): add drag-to-close functionality to modal dialogs

### DIFF
--- a/ios/ci_post_clone.sh
+++ b/ios/ci_post_clone.sh
@@ -49,4 +49,17 @@ if [ ! -f "ios/Flutter/Generated.xcconfig" ]; then
   echo "FLUTTER_BUILD_MODE=release" >> ios/Flutter/Generated.xcconfig
 fi
 
+# Ensure Pods-Runner xcfilelist files exist
+PODS_RUNNER_DIR="ios/Pods/Target Support Files/Pods-Runner"
+if [ ! -f "$PODS_RUNNER_DIR/Pods-Runner.debug.xcfilelist" ]; then
+  echo "❗ Pods-Runner.debug.xcfilelist missing — create minimal fallback"
+  mkdir -p "$PODS_RUNNER_DIR"
+  echo "" > "$PODS_RUNNER_DIR/Pods-Runner.debug.xcfilelist"
+fi
+if [ ! -f "$PODS_RUNNER_DIR/Pods-Runner.release.xcfilelist" ]; then
+  echo "❗ Pods-Runner.release.xcfilelist missing — create minimal fallback"
+  mkdir -p "$PODS_RUNNER_DIR"
+  echo "" > "$PODS_RUNNER_DIR/Pods-Runner.release.xcfilelist"
+fi
+
 echo "✅ iOS CI Post-Clone Script complete"

--- a/lib/pages/homepage.dart
+++ b/lib/pages/homepage.dart
@@ -319,14 +319,21 @@ class _HomePageState extends State<HomePage> {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Center(
-                      child: Container(
-                        width: 40,
-                        height: 4,
-                        margin: const EdgeInsets.symmetric(vertical: 12),
-                        decoration: BoxDecoration(
-                          color: Colors.grey[300],
-                          borderRadius: BorderRadius.circular(2),
+                    GestureDetector(
+                      onVerticalDragEnd: (details) {
+                        if (details.primaryVelocity! > 0) {
+                          Navigator.of(context).pop();
+                        }
+                      },
+                      child: Center(
+                        child: Container(
+                          width: 40,
+                          height: 4,
+                          margin: const EdgeInsets.symmetric(vertical: 12),
+                          decoration: BoxDecoration(
+                            color: Colors.grey[300],
+                            borderRadius: BorderRadius.circular(2),
+                          ),
                         ),
                       ),
                     ),
@@ -1100,14 +1107,21 @@ class _HomePageState extends State<HomePage> {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Center(
-                        child: Container(
-                          width: 40,
-                          height: 4,
-                          margin: const EdgeInsets.symmetric(vertical: 12),
-                          decoration: BoxDecoration(
-                            color: Colors.grey[300],
-                            borderRadius: BorderRadius.circular(2),
+                      GestureDetector(
+                        onVerticalDragEnd: (details) {
+                          if (details.primaryVelocity! > 0) {
+                            Navigator.of(context).pop();
+                          }
+                        },
+                        child: Center(
+                          child: Container(
+                            width: 40,
+                            height: 4,
+                            margin: const EdgeInsets.symmetric(vertical: 12),
+                            decoration: BoxDecoration(
+                              color: Colors.grey[300],
+                              borderRadius: BorderRadius.circular(2),
+                            ),
                           ),
                         ),
                       ),

--- a/lib/util/dialogue_box.dart
+++ b/lib/util/dialogue_box.dart
@@ -182,14 +182,22 @@ class _DialogueBoxState extends State<DialogueBox> {
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Center(
-                          child: Container(
-                            width: 40,
-                            height: 4,
-                            margin: const EdgeInsets.symmetric(vertical: 12),
-                            decoration: BoxDecoration(
-                              color: Colors.grey[300],
-                              borderRadius: BorderRadius.circular(2),
+                        GestureDetector(
+                          onVerticalDragEnd: (details) {
+                            if (details.primaryVelocity! > 0) {
+                              // Dragging down - close the modal
+                              Navigator.of(context).pop();
+                            }
+                          },
+                          child: Center(
+                            child: Container(
+                              width: 40,
+                              height: 4,
+                              margin: const EdgeInsets.symmetric(vertical: 12),
+                              decoration: BoxDecoration(
+                                color: Colors.grey[300],
+                                borderRadius: BorderRadius.circular(2),
+                              ),
                             ),
                           ),
                         ),
@@ -199,7 +207,9 @@ class _DialogueBoxState extends State<DialogueBox> {
                           child: Align(
                             alignment: Alignment.centerLeft,
                             child: Text(
-                              'Add New Agenda',
+                              widget.isEditing
+                                  ? 'Update Agenda'
+                                  : 'Add New Agenda',
                               style: TextStyle(
                                 fontSize: 24,
                                 fontWeight: FontWeight.bold,
@@ -843,71 +853,102 @@ class _DialogueBoxState extends State<DialogueBox> {
       ),
       builder: (context) => StatefulBuilder(
         builder: (context, setState) => Container(
-          padding: EdgeInsets.all(20),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                'Select Days for Notifications',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  fontFamily: 'Poppins',
-                ),
-              ),
-              SizedBox(height: 20),
-              Wrap(
-                spacing: 8.0,
-                runSpacing: 8.0,
-                children: List.generate(
-                  7,
-                  (index) => GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        _selectedDays[index] = !_selectedDays[index];
-                      });
-                      this.setState(() {});
-                      _validateNotificationFrequency();
-                    },
-                    child: Container(
-                      padding:
-                          EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                      decoration: BoxDecoration(
-                        color: _selectedDays[index]
-                            ? (isLightMode ? Colors.black : Colors.white)
-                            : (isLightMode
-                                ? Colors.grey[200]
-                                : Colors.grey[700]),
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: Text(
-                        _daysOfWeek[index],
-                        style: TextStyle(
-                          color: _selectedDays[index]
-                              ? (isLightMode ? Colors.white : Colors.black)
-                              : (isLightMode ? Colors.black87 : Colors.white70),
-                          fontWeight: _selectedDays[index]
-                              ? FontWeight.bold
-                              : FontWeight.normal,
-                        ),
-                      ),
+              GestureDetector(
+                onVerticalDragEnd: (details) {
+                  if (details.primaryVelocity! > 0) {
+                    Navigator.of(context).pop();
+                  }
+                },
+                child: Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    margin: const EdgeInsets.symmetric(vertical: 12),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[300],
+                      borderRadius: BorderRadius.circular(2),
                     ),
                   ),
                 ),
               ),
-              SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.pop(context);
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: isLightMode ? Colors.black : Colors.white,
-                  foregroundColor: isLightMode ? Colors.white : Colors.black,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(20),
-                  ),
+              Padding(
+                padding: EdgeInsets.all(20),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Select Days for Notifications',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        fontFamily: 'Poppins',
+                      ),
+                    ),
+                    SizedBox(height: 20),
+                    Wrap(
+                      spacing: 8.0,
+                      runSpacing: 8.0,
+                      children: List.generate(
+                        7,
+                        (index) => GestureDetector(
+                          onTap: () {
+                            setState(() {
+                              _selectedDays[index] = !_selectedDays[index];
+                            });
+                            this.setState(() {});
+                            _validateNotificationFrequency();
+                          },
+                          child: Container(
+                            padding: EdgeInsets.symmetric(
+                                horizontal: 16, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: _selectedDays[index]
+                                  ? (isLightMode ? Colors.black : Colors.white)
+                                  : (isLightMode
+                                      ? Colors.grey[200]
+                                      : Colors.grey[700]),
+                              borderRadius: BorderRadius.circular(20),
+                            ),
+                            child: Text(
+                              _daysOfWeek[index],
+                              style: TextStyle(
+                                color: _selectedDays[index]
+                                    ? (isLightMode
+                                        ? Colors.white
+                                        : Colors.black)
+                                    : (isLightMode
+                                        ? Colors.black87
+                                        : Colors.white70),
+                                fontWeight: _selectedDays[index]
+                                    ? FontWeight.bold
+                                    : FontWeight.normal,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 20),
+                    ElevatedButton(
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor:
+                            isLightMode ? Colors.black : Colors.white,
+                        foregroundColor:
+                            isLightMode ? Colors.white : Colors.black,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                      ),
+                      child: Text('Done'),
+                    ),
+                  ],
                 ),
-                child: Text('Done'),
               ),
             ],
           ),

--- a/lib/widgets/agenda_details_modal.dart
+++ b/lib/widgets/agenda_details_modal.dart
@@ -85,16 +85,23 @@ class _AgendaDetailsModalState extends State<AgendaDetailsModal> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Container(
-              width: double.infinity,
-              alignment: Alignment.center,
+            GestureDetector(
+              onVerticalDragEnd: (details) {
+                if (details.primaryVelocity! > 0) {
+                  Navigator.of(context).pop();
+                }
+              },
               child: Container(
-                width: 40,
-                height: 4,
-                margin: const EdgeInsets.symmetric(vertical: 12),
-                decoration: BoxDecoration(
-                  color: Colors.grey[300],
-                  borderRadius: BorderRadius.circular(2),
+                width: double.infinity,
+                alignment: Alignment.center,
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  margin: const EdgeInsets.symmetric(vertical: 12),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(2),
+                  ),
                 ),
               ),
             ),

--- a/lib/widgets/category_dialog.dart
+++ b/lib/widgets/category_dialog.dart
@@ -52,15 +52,21 @@ class _CategoryDialogState extends State<CategoryDialog> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            // Handle bar at top
-            Center(
-              child: Container(
-                width: 40,
-                height: 4,
-                margin: const EdgeInsets.symmetric(vertical: 12),
-                decoration: BoxDecoration(
-                  color: Colors.grey[300],
-                  borderRadius: BorderRadius.circular(2),
+            GestureDetector(
+              onVerticalDragEnd: (details) {
+                if (details.primaryVelocity! > 0) {
+                  Navigator.of(context).pop();
+                }
+              },
+              child: Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  margin: const EdgeInsets.symmetric(vertical: 12),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(2),
+                  ),
                 ),
               ),
             ),

--- a/lib/widgets/category_selector.dart
+++ b/lib/widgets/category_selector.dart
@@ -159,72 +159,96 @@ class _CategorySelectorState extends State<CategorySelector> {
           color: isLightMode ? Colors.white : Colors.grey[850],
           borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
         ),
-        child: Padding(
-          padding: const EdgeInsets.all(20.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  'Add New Category',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    fontFamily: 'Poppins',
-                    color: isLightMode ? Colors.black : Colors.white,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GestureDetector(
+              onVerticalDragEnd: (details) {
+                if (details.primaryVelocity! > 0) {
+                  Navigator.of(context).pop();
+                }
+              },
+              child: Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  margin: const EdgeInsets.symmetric(vertical: 12),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(2),
                   ),
                 ),
               ),
-              SizedBox(height: 16),
-              TextField(
-                controller: _newCategoryController,
-                decoration: InputDecoration(
-                  hintText: 'Enter category name',
-                  hintStyle: TextStyle(
-                    color: isLightMode ? Colors.black26 : Colors.grey[100],
-                  ),
-                  filled: true,
-                  fillColor: isLightMode ? Colors.grey[100] : Colors.grey[800],
-                  border: UnderlineInputBorder(),
-                ),
-                autofocus: true,
-              ),
-              SizedBox(height: 20),
-              Center(
-                child: ElevatedButton(
-                  onPressed: () {
-                    if (_newCategoryController.text.isNotEmpty) {
-                      final newCategory = _newCategoryController.text;
-                      setState(() {
-                        _selectedCategory = newCategory;
-                      });
-                      widget.onNewCategoryAdded(newCategory);
-                      widget.onCategorySelected(newCategory);
-                      _newCategoryController.clear();
-                      Navigator.pop(context);
-                    }
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: isLightMode ? Colors.black : Colors.white,
-                    foregroundColor: isLightMode ? Colors.white : Colors.black,
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 100, vertical: 16),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(24),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(20.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'Add New Category',
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                        fontFamily: 'Poppins',
+                        color: isLightMode ? Colors.black : Colors.white,
+                      ),
                     ),
                   ),
-                  child: const Text('Create',
-                      style: TextStyle(
-                        fontFamily: 'Poppins',
-                        fontWeight: FontWeight.w600,
-                        fontSize: 14,
-                      )),
-                ),
+                  SizedBox(height: 16),
+                  TextField(
+                    controller: _newCategoryController,
+                    decoration: InputDecoration(
+                      hintText: 'Enter category name',
+                      hintStyle: TextStyle(
+                        color: isLightMode ? Colors.black26 : Colors.grey[100],
+                      ),
+                      filled: true,
+                      fillColor: isLightMode ? Colors.grey[100] : Colors.grey[800],
+                      border: UnderlineInputBorder(),
+                    ),
+                    autofocus: true,
+                  ),
+                  SizedBox(height: 20),
+                  Center(
+                    child: ElevatedButton(
+                      onPressed: () {
+                        if (_newCategoryController.text.isNotEmpty) {
+                          final newCategory = _newCategoryController.text;
+                          setState(() {
+                            _selectedCategory = newCategory;
+                          });
+                          widget.onNewCategoryAdded(newCategory);
+                          widget.onCategorySelected(newCategory);
+                          _newCategoryController.clear();
+                          Navigator.pop(context);
+                        }
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: isLightMode ? Colors.black : Colors.white,
+                        foregroundColor: isLightMode ? Colors.white : Colors.black,
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 100, vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(24),
+                        ),
+                      ),
+                      child: const Text('Create',
+                          style: TextStyle(
+                            fontFamily: 'Poppins',
+                            fontWeight: FontWeight.w600,
+                            fontSize: 14,
+                          )),
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/widgets/filter_dialog.dart
+++ b/lib/widgets/filter_dialog.dart
@@ -61,15 +61,21 @@ class _FilterDialogState extends State<FilterDialog> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Handle bar at top
-                  Center(
-                    child: Container(
-                      width: 40,
-                      height: 4,
-                      margin: const EdgeInsets.symmetric(vertical: 12),
-                      decoration: BoxDecoration(
-                        color: Colors.grey[300],
-                        borderRadius: BorderRadius.circular(2),
+                  GestureDetector(
+                    onVerticalDragEnd: (details) {
+                      if (details.primaryVelocity! > 0) {
+                        Navigator.of(context).pop();
+                      }
+                    },
+                    child: Center(
+                      child: Container(
+                        width: 40,
+                        height: 4,
+                        margin: const EdgeInsets.symmetric(vertical: 12),
+                        decoration: BoxDecoration(
+                          color: Colors.grey[300],
+                          borderRadius: BorderRadius.circular(2),
+                        ),
                       ),
                     ),
                   ),
@@ -242,15 +248,23 @@ class _FilterDialogState extends State<FilterDialog> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Handle bar at top
-                  Center(
-                    child: Container(
-                      width: 40,
-                      height: 4,
-                      margin: const EdgeInsets.symmetric(vertical: 12),
-                      decoration: BoxDecoration(
-                        color: Colors.grey[300],
-                        borderRadius: BorderRadius.circular(2),
+                  // Handle bar at top - now draggable
+                  GestureDetector(
+                    onVerticalDragEnd: (details) {
+                      if (details.primaryVelocity! > 0) {
+                        // Dragging down - close the modal
+                        Navigator.of(context).pop();
+                      }
+                    },
+                    child: Center(
+                      child: Container(
+                        width: 40,
+                        height: 4,
+                        margin: const EdgeInsets.symmetric(vertical: 12),
+                        decoration: BoxDecoration(
+                          color: Colors.grey[300],
+                          borderRadius: BorderRadius.circular(2),
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
Implement gesture detection for vertical drag events to allow users to close modal dialogs by swiping down. This improves user experience by providing a more intuitive way to dismiss modals. Changes applied to multiple dialog widgets including `category_dialog`, `agenda_details_modal`, `filter_dialog`, and `category_selector`.